### PR TITLE
Update active.cabal

### DIFF
--- a/active.cabal
+++ b/active.cabal
@@ -32,7 +32,7 @@ library
 test-suite active-tests
     type:              exitcode-stdio-1.0
     main-is:           active-tests.hs
-    build-depends:     base >= 4.0 && < 4.14,
+    build-depends:     base >= 4.0 && < 4.15,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,


### PR DESCRIPTION
allow 4.14 for tests, too